### PR TITLE
Allow extra params to be passed when creating Oauth user

### DIFF
--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -67,7 +67,7 @@ export const callbackOAuth = createAuthEndpoint(
 				`${c.context.baseURL}/error?error=oauth_provider_not_found`,
 			);
 		}
-		const { codeVerifier, callbackURL, link, errorURL, newUserURL } =
+		const { codeVerifier, callbackURL, link, errorURL, newUserURL, extraData } =
 			await parseState(c);
 
 		let tokens: OAuth2Tokens;
@@ -84,7 +84,7 @@ export const callbackOAuth = createAuthEndpoint(
 			);
 		}
 		const userInfo = await provider
-			.getUserInfo(tokens)
+			.getUserInfo(tokens, extraData)
 			.then((res) => res?.user);
 
 		function redirectOnError(error: string) {

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -55,6 +55,17 @@ export const signInSocial = createAuthEndpoint(
 			provider: z.enum(socialProviderList, {
 				description: "OAuth2 provider to use",
 			}),
+
+			/**
+			 * Additional data to be passed to createOauthUser
+			 * 
+			 * useful if you want to pass additional data when creating an OAuth user
+			 * such as a user role for instance
+			 */
+			data: z.optional(
+				z.record(z.string())
+			),
+			
 			/**
 			 * Disable automatic redirection to the provider
 			 *

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -30,12 +30,14 @@ export async function generateState(
 		codeVerifier,
 		errorURL: c.body?.errorCallbackURL || c.query?.currentURL,
 		newUserURL: c.body?.newUserCallbackURL,
+		extraData: c.body?.data,
 		link,
 		/**
 		 * This is the actual expiry time of the state
 		 */
 		expiresAt: Date.now() + 10 * 60 * 1000,
 	});
+
 	const expiresAt = new Date();
 	expiresAt.setMinutes(expiresAt.getMinutes() + 10);
 	const verification = await c.context.internalAdapter.createVerificationValue({
@@ -74,6 +76,7 @@ export async function parseState(c: GenericEndpointContext) {
 			codeVerifier: z.string(),
 			errorURL: z.string().optional(),
 			newUserURL: z.string().optional(),
+			extraData: z.record(z.string()),
 			expiresAt: z.number(),
 			link: z
 				.object({

--- a/packages/better-auth/src/oauth2/types.ts
+++ b/packages/better-auth/src/oauth2/types.ts
@@ -27,7 +27,7 @@ export interface OAuthProvider<
 		redirectURI: string;
 		codeVerifier?: string;
 	}) => Promise<OAuth2Tokens>;
-	getUserInfo: (token: OAuth2Tokens) => Promise<{
+	getUserInfo: (token: OAuth2Tokens, extraData?: Record<string, unknown>) => Promise<{
 		user: {
 			id: string;
 			name?: string;


### PR DESCRIPTION
This MR adds support for extra data to be passed while registering a user through the OAuth process. 
